### PR TITLE
support newline with "return" in normal mode

### DIFF
--- a/lib/normal-mode.js
+++ b/lib/normal-mode.js
@@ -177,6 +177,10 @@ module.exports = function createNormalMode(
       // enter
       case 'enter':
         return rli._line(), insertMode();
+
+      // return
+      case 'return':
+        return rli._line();
     }
 
     switch (code) {

--- a/test/move-enter.js
+++ b/test/move-enter.js
@@ -1,0 +1,14 @@
+'use strict';
+/*jshint asi: true*/
+
+var test = require('tap').test
+  , hns = require('./utils/harness')()
+
+test('move on enter', function (t) {
+  t.equal(hns.rli.lines, 0, hns.seqed + 'enters on init in normal mode')
+
+  hns.seq('enter')
+  t.equal(hns.rli.lines, 1, hns.seqed + 'enters in normal mode')
+
+  t.end()
+})


### PR DESCRIPTION
support newline with "return" in normal mode

the key code when hitting enter on os x is:
{ name: 'return',
ctrl: false,
meta: false,
shift: false,
sequence: '\r' }

when in normal mode without this patch, no new line is opened.
